### PR TITLE
♻️ Improve CMake build system configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,13 +31,9 @@ add_library(ldpc INTERFACE)
 # Add specific directories to the include path for any target that links with the 'ldpc' library
 target_include_directories(ldpc INTERFACE src_cpp include/robin_map include/rapidcsv)
 
-### Executable Configuration Section ###
-
-# Add an executable target named 'main', which is built from the 'main.cpp' source file
-add_executable(main cpp_example/main.cpp)
-
-# Link the 'ldpc' library to the 'main' executable target
-target_link_libraries(main ldpc)
+if (LDPC_MASTER_PROJECT)
+	add_subdirectory(cpp_example)
+endif()
 
 if(BUILD_LDPC_TESTS)
 	# Add test code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,6 @@ project(ldpc
     DESCRIPTION "ldpc - Software for classical and quantum low density parity check codes"
     LANGUAGES CXX)
 
-# Set the C++ standard to C++20 for this project
-set(CMAKE_CXX_STANDARD 20)
-
 # Enable OpenMP support for parallel programming
 # SET(CMAKE_CXX_FLAGS  "-fopenmp")
 
@@ -30,6 +27,9 @@ add_library(ldpc INTERFACE)
 
 # Add specific directories to the include path for any target that links with the 'ldpc' library
 target_include_directories(ldpc INTERFACE src_cpp include/robin_map include/rapidcsv)
+
+# Set the required C++ standard
+target_compile_features(ldpc INTERFACE cxx_std_20)
 
 if (LDPC_MASTER_PROJECT)
 	add_subdirectory(cpp_example)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Set the minimum version of CMake required to build this project
-cmake_minimum_required(VERSION 3.10...3.30)
+cmake_minimum_required(VERSION 3.12...3.30)
 
 # Enable the testing functionality provided by CMake
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Set the minimum version of CMake required to build this project
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.30)
 
 # Enable the testing functionality provided by CMake
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.12...3.30)
 enable_testing()
 
 # Define the main project, its description, and the languages used
-project(main
+project(ldpc
     DESCRIPTION "ldpc - Software for classical and quantum low density parity check codes"
     LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 # Set the minimum version of CMake required to build this project
 cmake_minimum_required(VERSION 3.12...3.30)
 
-# Enable the testing functionality provided by CMake
-enable_testing()
-
 # Define the main project, its description, and the languages used
 project(ldpc
     DESCRIPTION "ldpc - Software for classical and quantum low density parity check codes"
@@ -17,6 +14,14 @@ set(CMAKE_CXX_STANDARD 20)
 
 # Ensure that the necessary C++11 features are available, as required by the RapidCSV library
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# check if this is the master project or used via add_subdirectory
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+	set(LDPC_MASTER_PROJECT ON)
+else()
+	set(LDPC_MASTER_PROJECT OFF)
+endif()
+option(BUILD_LDPC_TESTS "Also build tests for the LDPC project" ${LDPC_MASTER_PROJECT})
 
 ### Library Configuration Section ###
 
@@ -34,57 +39,9 @@ add_executable(main cpp_example/main.cpp)
 # Link the 'ldpc' library to the 'main' executable target
 target_link_libraries(main ldpc)
 
-### GoogleTest Configuration Section ###
-
-# Download the GoogleTest library as a subdirectory of the current project
-include(FetchContent)
-FetchContent_Declare(
-  GoogleTest
-  URL ${CMAKE_CURRENT_SOURCE_DIR}/cpp_test/google_test.zip
-)
-
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
-# Make the GoogleTest library available to the project
-FetchContent_MakeAvailable(GoogleTest)
-
-### Test Configuration Section ###
-
-# Define a separate project for the tests, its description, and the languages used
-project(cpp_test
-    DESCRIPTION "Tests for ldpc"
-    LANGUAGES CXX)
-
-# Include the GoogleTest library in the project
-include(GoogleTest)
-
-# List of test executables
-set(TEST_EXECUTABLES
-    TestBPDecoder
-    TestOsdDecoder
-    TestSoftInfo
-    TestFlipDecoder
-    TestGf2Codes
-    TestLsd
-    TestSparseMatrix
-    TestSparseMatrixUtil
-    TestGF2Sparse
-    TestGF2RowReduce
-    TestGf2Linalg
-    TestGf2Dense
-    TestGf2DenseApplications
-    TestUtil
-    TestRng
-    TestUnionFind
-)
-
-# Loop through the list of test executables to:
-# - Add each executable target
-# - Link the necessary libraries (gtest_main and ldpc)
-# - Discover and register the tests with CTest
-foreach(TEST ${TEST_EXECUTABLES})
-    add_executable(${TEST} cpp_test/${TEST}.cpp)  # Add the test executable
-    target_link_libraries(${TEST} gtest_main ldpc)  # Link the libraries
-    gtest_discover_tests(${TEST})  # Discover and register the tests
-endforeach()
+if(BUILD_LDPC_TESTS)
+	# Add test code
+	enable_testing()
+	include(GoogleTest)
+	add_subdirectory(cpp_test)
+endif()

--- a/cpp_example/CMakeLists.txt
+++ b/cpp_example/CMakeLists.txt
@@ -1,0 +1,7 @@
+### Executable Configuration Section ###
+
+# Add an executable target named 'ldpc-main', which is built from the 'main.cpp' source file
+add_executable(ldpc-main main.cpp)
+
+# Link the 'ldpc' library to the 'ldpc-main' executable target
+target_link_libraries(ldpc-main PRIVATE ldpc)

--- a/cpp_test/CMakeLists.txt
+++ b/cpp_test/CMakeLists.txt
@@ -1,0 +1,46 @@
+### GoogleTest Configuration Section ###
+
+# Download the GoogleTest library as a subdirectory of the current project
+include(FetchContent)
+FetchContent_Declare(
+	GoogleTest
+	URL ${CMAKE_CURRENT_SOURCE_DIR}/google_test.zip
+)
+
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Make the GoogleTest library available to the project
+FetchContent_MakeAvailable(GoogleTest)
+
+### Test Configuration Section ###
+
+# List of test executables
+set(TEST_EXECUTABLES
+    TestBPDecoder
+    TestOsdDecoder
+    TestSoftInfo
+    TestFlipDecoder
+    TestGf2Codes
+    TestLsd
+    TestSparseMatrix
+    TestSparseMatrixUtil
+    TestGF2Sparse
+    TestGF2RowReduce
+    TestGf2Linalg
+    TestGf2Dense
+    TestGf2DenseApplications
+    TestUtil
+    TestRng
+    TestUnionFind
+)
+
+# Loop through the list of test executables to:
+# - Add each executable target
+# - Link the necessary libraries (gtest_main and ldpc)
+# - Discover and register the tests with CTest
+foreach(TEST ${TEST_EXECUTABLES})
+	add_executable(${TEST} ${TEST}.cpp)  # Add the test executable
+	target_link_libraries(${TEST} PRIVATE gtest_main ldpc)  # Link the libraries
+	gtest_discover_tests(${TEST})  # Discover and register the tests
+endforeach()


### PR DESCRIPTION
Hey 👋🏼 

while working on the integration of this library into our MQT QECC project I couldn't help but notice that this project could use a little bit of an update in its CMake configuration.
Consider this PR such an effort.
I tried to keep the individual changes isolated so it should be pretty straight-forward to follow the individual commits.
Let me know if anything is unclear or whether you'd prefer to do certain things differently.

The biggest user-facing changes:
- no more warning during the CMake configure about FetchContent
- no need to configure and build tests or the main executable if the library is just used as a submodule
- less likely to result in naming conflicts (`main` as project and executable)