### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/src_python/ldpc/__init__.py
+++ b/src_python/ldpc/__init__.py
@@ -1,6 +1,6 @@
-import pkg_resources
+import importlib.metadata
 
-__version__ = pkg_resources.get_distribution("ldpc").version
+__version__ = importlib.metadata.version("ldpc")
 
 from ldpc.bp_decoder import BpDecoder
 from ldpc.bposd_decoder import BpOsdDecoder


### PR DESCRIPTION
From https://setuptools.pypa.io/en/latest/pkg_resources.html:

> Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)).